### PR TITLE
Implement social feed ingestion utilities

### DIFF
--- a/apps/worker/feeds.py
+++ b/apps/worker/feeds.py
@@ -1,0 +1,43 @@
+"""Utility functions for ingesting social feeds via RSS."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import List, Dict
+
+import httpx
+
+
+async def fetch_rss(url: str) -> str:
+    """Fetch raw RSS feed text from the given URL."""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.text
+
+
+def parse_rss(xml_text: str) -> List[Dict[str, str]]:
+    """Parse RSS XML into a list of posts with title and link."""
+    root = ET.fromstring(xml_text)
+    posts: List[Dict[str, str]] = []
+    for item in root.findall(".//item"):
+        title = item.findtext("title")
+        link = item.findtext("link")
+        if title and link:
+            posts.append({"title": title, "link": link})
+    return posts
+
+
+async def ingest_twitter(handle: str) -> List[Dict[str, str]]:
+    """Return recent tweets for the handle via nitter RSS."""
+    url = f"https://nitter.net/{handle}/rss"
+    xml = await fetch_rss(url)
+    return parse_rss(xml)
+
+
+async def ingest_youtube(channel_id: str) -> List[Dict[str, str]]:
+    """Return recent YouTube uploads for the channel via RSS."""
+    url = f"https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
+    xml = await fetch_rss(url)
+    return parse_rss(xml)
+

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1,0 +1,29 @@
+import asyncio
+import pytest
+from apps.worker import feeds
+
+SAMPLE_RSS = """
+<rss><channel>
+  <item><title>First post</title><link>https://example.com/1</link></item>
+  <item><title>Second post</title><link>https://example.com/2</link></item>
+</channel></rss>
+"""
+
+
+def test_parse_rss():
+    posts = feeds.parse_rss(SAMPLE_RSS)
+    assert posts == [
+        {"title": "First post", "link": "https://example.com/1"},
+        {"title": "Second post", "link": "https://example.com/2"},
+    ]
+
+
+def test_ingest_twitter(monkeypatch):
+    async def fake_fetch(url: str) -> str:
+        return SAMPLE_RSS
+
+    monkeypatch.setattr(feeds, "fetch_rss", fake_fetch)
+    posts = asyncio.run(feeds.ingest_twitter("user"))
+    assert len(posts) == 2
+    assert posts[0]["title"] == "First post"
+


### PR DESCRIPTION
## Summary
- add RSS feed ingestion helpers for Twitter and YouTube
- include parsing logic for RSS items
- test feed ingestion and parsing

## Testing
- `pytest -q`