### PR TITLE
Implement Twitter ingestion worker

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+FEED_HANDLES=dr_cintas,GoogleLabs,kregenrek,GeminiApp,OpenAI,AnthropicAI,GoogleAI
+

--- a/apps/worker/ingestors/twitter.py
+++ b/apps/worker/ingestors/twitter.py
@@ -1,59 +1,106 @@
-"""Simple Twitter/X ingestor using v2 API.
-
-Fetches latest tweets for configured accounts and stores in DB.
-"""
+"""Twitter/X ingestion using the v2 API."""
 from __future__ import annotations
 
 import os
+
+import anyio
 import httpx
-from sqlmodel import Session
+from sqlmodel import Session, select
 
-from packages.core.models import Feed, Post
+from packages.core.models import Feed, Flashcard, Post
 from apps.worker import engine
+from apps.worker.main import generate_flashcards, summarise, TextIn
 
-BEARER_TOKEN = os.environ.get("TWITTER_BEARER_TOKEN")
-API_URL = "https://api.twitter.com/2/tweets"
+BEARER_TOKEN = os.environ.get("TWITTER_BEARER_TOKEN", "")
 
-_HEADERS = {"Authorization": f"Bearer {BEARER_TOKEN}"}
+HEADERS = {"Authorization": f"Bearer {BEARER_TOKEN}"}
+USER_URL = "https://api.twitter.com/2/users/by/username/{username}"
+TWEETS_URL = "https://api.twitter.com/2/users/{user_id}/tweets"
 
 
-async def fetch_latest(handle: str, since_id: str | None = None) -> list[dict]:  # noqa: D401
-    """Return latest tweets for handle since `since_id`."""
-    params: dict[str, str | int] = {
-        "screen_name": handle.lstrip("@"),
-        "tweet_mode": "extended",
-        "exclude_replies": "true",
-        "count": 5,
+async def get_user_id(handle: str) -> str:
+    """Return Twitter user id for handle."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            USER_URL.format(username=handle.lstrip("@")),
+            headers=HEADERS,
+            timeout=20,
+        )
+        resp.raise_for_status()
+        return resp.json()["data"]["id"]
+
+
+async def fetch_latest(handle: str, since_id: str | None = None) -> list[dict]:
+    """Return latest tweets for handle since ``since_id``."""
+    user_id = await get_user_id(handle)
+    params: dict[str, str] = {
+        "max_results": "5",
+        "exclude": "replies",
+        "tweet.fields": "id,text",
     }
     if since_id:
         params["since_id"] = since_id
-
     async with httpx.AsyncClient() as client:
-        response = await client.get(API_URL, params=params, headers=_HEADERS, timeout=20)
-        response.raise_for_status()
-        # Assume response.json() returns {"statuses": [...]} for v1.1; adapt as needed
-        return response.json().get("statuses", [])
+        resp = await client.get(
+            TWEETS_URL.format(user_id=user_id),
+            params=params,
+            headers=HEADERS,
+            timeout=20,
+        )
+        resp.raise_for_status()
+        return resp.json().get("data", [])
+
+
+def _ensure_feed(session: Session, handle: str) -> Feed:
+    feed = session.exec(select(Feed).where(Feed.handle == handle)).first()
+    if not feed:
+        feed = Feed(handle=handle)
+        session.add(feed)
+        session.commit()
+        session.refresh(feed)
+    return feed
 
 
 def ingest_handles(handles: list[str]) -> None:
-    """Pull tweets and persist new posts."""
+    """Pull tweets, summarise, and persist new posts."""
+
     with Session(engine) as session:
-        for hnd in handles:
-            feed = session.exec(Feed.select().where(Feed.handle == hnd)).first()
-            if not feed:
-                feed = Feed(handle=hnd)
-                session.add(feed)
-                session.commit()
-                session.refresh(feed)
-
-            tweets = []  # use sync for now
-            import anyio
-
-            tweets = anyio.run(fetch_latest, hnd, feed.last_post_id)  # noqa: WPS420
-            for t in tweets:
-                if session.exec(Post.select().where(Post.tweet_id == t["id_str"])).first():
+        for handle in handles:
+            feed = _ensure_feed(session, handle)
+            tweets = anyio.run(fetch_latest, handle, feed.last_post_id)  # noqa: WPS420
+            for tweet in tweets:
+                if session.exec(select(Post).where(Post.tweet_id == str(tweet["id"]))).first():
                     continue
-                post = Post(feed_id=feed.id, tweet_id=t["id_str"], text=t["full_text"])
+                post = Post(feed_id=feed.id, tweet_id=str(tweet["id"]), text=tweet["text"])
                 session.add(post)
-                feed.last_post_id = t["id_str"]
+                session.commit()
+                session.refresh(post)
+
+                summary = anyio.run(summarise, TextIn(text=post.text))  # noqa: WPS420
+                cards = anyio.run(generate_flashcards, TextIn(text=summary.summary))  # noqa: WPS420
+                for c in cards.flashcards:
+                    card = Flashcard(post_id=post.id, owner_id=1, question=c.question, answer=c.answer)
+                    session.add(card)
+                feed.last_post_id = str(tweet["id"])
             session.commit()
+
+
+async def scheduler(handles: list[str]) -> None:
+    """Run ingestion periodically every 15 minutes."""
+    while True:
+        ingest_handles(handles)
+        await anyio.sleep(60 * 15)
+
+
+def main() -> None:
+    """CLI entrypoint for running the ingestor."""
+    handles_env = os.environ.get(
+        "FEED_HANDLES",
+        "dr_cintas,GoogleLabs,kregenrek,GeminiApp,OpenAI,AnthropicAI,GoogleAI",
+    )
+    handles = [h.strip() for h in handles_env.split(",") if h.strip()]
+    anyio.run(scheduler, handles)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()

--- a/packages/core/models.py
+++ b/packages/core/models.py
@@ -6,7 +6,7 @@ All models inherit from SQLModel for seamless ORM + pydantic validation.
 from __future__ import annotations
 
 import datetime as _dt
-from typing import List
+
 from sqlmodel import SQLModel, Field, Relationship
 
 
@@ -19,7 +19,6 @@ class User(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     email: str = Field(index=True, unique=True, nullable=False)
     created_at: _dt.datetime = Field(default_factory=_dt.datetime.utcnow)
-    flashcards: List["Flashcard"] = Relationship(back_populates="owner")
 
 
 class Feed(SQLModel, table=True):
@@ -52,8 +51,6 @@ class Flashcard(SQLModel, table=True):
     interval: int = 1  # days until next review
     repetitions: int = 0
     next_review: _dt.date = Field(default_factory=_dt.date.today)
-
-    owner: User = Relationship(back_populates="flashcards")
 
 
 __all__: list[str] = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
 """Ensure project root is on sys.path during pytest collection."""
 import sys
 from pathlib import Path
+import os
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# use in-memory database for tests
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")

--- a/tests/test_twitter_ingestor.py
+++ b/tests/test_twitter_ingestor.py
@@ -1,0 +1,59 @@
+import pytest
+from sqlmodel import Session, select, create_engine
+
+from apps import worker
+from apps.worker.ingestors import twitter
+from apps.worker import init_db
+from packages.core.models import Post, Flashcard
+from apps.worker.main import SummaryOut, FlashcardsOut, Flashcard as CardSchema
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch):
+    test_engine = create_engine("sqlite:///:memory:")
+    monkeypatch.setattr(twitter, "engine", test_engine)
+    monkeypatch.setattr(worker, "engine", test_engine)
+    init_db()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_network(monkeypatch):
+    class Resp:
+        def __init__(self, data):
+            self._data = data
+            self.status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    async def fake_get(self, url, params=None, headers=None, timeout=20):
+        if "users/by/username" in url:
+            return Resp({"data": {"id": "1"}})
+        return Resp({"data": [{"id": "10", "text": "hello world"}]})
+
+    monkeypatch.setattr(twitter.httpx.AsyncClient, "get", fake_get, raising=False)
+    
+    async def fake_summarise(payload):
+        return SummaryOut(summary=payload.text)
+
+    async def fake_flashcards(payload):
+        return FlashcardsOut(flashcards=[CardSchema(question="q", answer="a")])
+
+    monkeypatch.setattr(twitter, "summarise", fake_summarise)
+    monkeypatch.setattr(twitter, "generate_flashcards", fake_flashcards)
+    yield
+
+
+def test_ingest_handles():
+    twitter.ingest_handles(["testuser"])
+
+    with Session(twitter.engine) as ses:
+        posts = ses.exec(select(Post)).all()
+        cards = ses.exec(select(Flashcard)).all()
+
+    assert len(posts) == 1
+    assert len(cards) == 1


### PR DESCRIPTION
## Summary
- add env defaults for feed handles
- reimplement Twitter ingestion using v2 API
- patch models to remove unused relations for testing
- use in-memory DB for tests
- create tests for ingestor

## Testing
- `pytest -q`