### PR TITLE
Expose core API endpoints

### DIFF
--- a/apps/worker/main.py
+++ b/apps/worker/main.py
@@ -2,50 +2,151 @@
 
 Provides a simple health-check route for now.
 """
-from fastapi import FastAPI
-from openai import AsyncOpenAI
+from fastapi import FastAPI, HTTPException
+from openai import AsyncOpenAI, OpenAIError
 import os
-from .schemas import TextIn, SummaryOut, Flashcard, FlashcardsOut
+from sqlmodel import Session, select
+import datetime as dt
+
+from .schemas import (
+    TextIn,
+    SummaryOut,
+    Flashcard,
+    FlashcardsOut,
+    FlashcardsDBOut,
+    ReviewIn,
+    ReviewOut,
+    FlashcardDB,
+)
+from packages.core.models import User, Feed, Post, Flashcard as DBFlashcard
+from packages.core.spaced_repetition import sm2
+from . import engine, init_db
+
+init_db()
 
 app = FastAPI(title="Vibe Coder Flashcards Worker")
 
 client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY", "test"))
 
 
-@app.get("/")
-async def health_check() -> dict[str, str]:
+@app.get("/", include_in_schema=False)
+async def root_health() -> dict[str, str]:
     """Health-check endpoint used by tests & uptime monitors."""
+    return {"status": "ok"}
+
+
+@app.get("/health", summary="Health check")
+async def health_check() -> dict[str, str]:
+    """Health-check endpoint used by uptime monitors."""
     return {"status": "ok"}
 
 
 @app.post("/summarise", response_model=SummaryOut)
 async def summarise(payload: TextIn) -> SummaryOut:
     """Return a concise summary of the provided text."""
-    chat = await client.chat.completions.create(
-        model="gpt-3.5-turbo",  # small cheap model
-        messages=[{"role": "user", "content": f"Summarise:\n{payload.text}"}],
-        max_tokens=128,
-    )
+    try:
+        chat = await client.chat.completions.create(
+            model="gpt-3.5-turbo",  # small cheap model
+            messages=[{"role": "user", "content": f"Summarise:\n{payload.text}"}],
+            max_tokens=128,
+        )
+    except OpenAIError as exc:  # pragma: no cover - network errors are mocked
+        raise HTTPException(status_code=502, detail="OpenAI error") from exc
     return SummaryOut(summary=chat.choices[0].message.content.strip())
 
 
-@app.post("/flashcards", response_model=FlashcardsOut)
-async def generate_flashcards(payload: TextIn) -> FlashcardsOut:
+@app.post("/flashcards", response_model=FlashcardsDBOut)
+async def generate_flashcards(payload: TextIn) -> FlashcardsDBOut:
     """Generate Q/A flashcards from input text."""
     prompt = (
         "Convert the following text to <=5 study flashcards in JSON array of objects "
         "with \"question\" & \"answer\" keys only. No extra keys. Text:\n" + payload.text
     )
-    chat = await client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": prompt}],
-        max_tokens=256,
-        response_format={"type": "json_object"},
-    )
+    try:
+        chat = await client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=256,
+            response_format={"type": "json_object"},
+        )
+    except OpenAIError as exc:  # pragma: no cover
+        raise HTTPException(status_code=502, detail="OpenAI error") from exc
     cards_data = chat.choices[0].message.content
     # simple parse – assumes correct JSON
     import json
 
     decoded = json.loads(cards_data)
     cards = [Flashcard(**c) for c in decoded]
-    return FlashcardsOut(flashcards=cards)
+
+    with Session(engine) as ses:
+        # ensure demo user/feed/post exist
+        user = ses.exec(select(User).where(User.id == 1)).first()
+        if not user:
+            user = User(id=1, email="demo@example.com")
+            ses.add(user)
+        feed = ses.exec(select(Feed).where(Feed.id == 1)).first()
+        if not feed:
+            feed = Feed(id=1, handle="manual")
+            ses.add(feed)
+        post = Post(feed_id=feed.id, tweet_id="manual", text=payload.text)
+        ses.add(post)
+        ses.commit()
+        ses.refresh(post)
+
+        out_cards: list[FlashcardDB] = []
+        for c in cards:
+            db_card = DBFlashcard(
+                owner_id=user.id,
+                post_id=post.id,
+                question=c.question,
+                answer=c.answer,
+            )
+            ses.add(db_card)
+            ses.commit()
+            ses.refresh(db_card)
+            out_cards.append(
+                FlashcardDB(id=db_card.id, question=db_card.question, answer=db_card.answer)
+            )
+    return FlashcardsDBOut(flashcards=out_cards)
+
+
+@app.get("/deck/today", response_model=FlashcardsDBOut)
+async def deck_today(user_id: int = 1) -> FlashcardsDBOut:
+    """Return flashcards due for review today."""
+    today = dt.date.today()
+    with Session(engine) as ses:
+        cards = ses.exec(
+            select(DBFlashcard).where(
+                DBFlashcard.owner_id == user_id,
+                DBFlashcard.next_review <= today,
+            ).limit(30)
+        ).all()
+        out = [
+            FlashcardDB(id=c.id, question=c.question, answer=c.answer) for c in cards
+        ]
+    return FlashcardsDBOut(flashcards=out)
+
+
+@app.post("/review", response_model=ReviewOut)
+async def review(payload: ReviewIn) -> ReviewOut:
+    """Update flashcard scheduling based on recall quality."""
+    with Session(engine) as ses:
+        card = ses.get(DBFlashcard, payload.flashcard_id)
+        if not card:
+            raise HTTPException(status_code=404, detail="Flashcard not found")
+
+        next_review, ease, interval, reps = sm2(
+            dt.date.today(),
+            payload.quality,
+            card.ease_factor,
+            card.interval,
+            card.repetitions,
+        )
+        card.next_review = next_review
+        card.ease_factor = ease
+        card.interval = interval
+        card.repetitions = reps
+        ses.add(card)
+        ses.commit()
+        ses.refresh(card)
+    return ReviewOut(id=card.id, next_review=str(card.next_review), interval=card.interval)

--- a/apps/worker/schemas.py
+++ b/apps/worker/schemas.py
@@ -6,7 +6,12 @@ from pydantic import BaseModel, Field
 class TextIn(BaseModel):
     """Input payload containing raw text to summarise."""
 
-    text: str = Field(..., min_length=1, description="Raw text to be summarised")
+    text: str = Field(
+        ...,
+        min_length=1,
+        description="Raw text to be summarised",
+        example="Python is a popular programming language.",
+    )
 
 
 class SummaryOut(BaseModel):
@@ -22,7 +27,34 @@ class Flashcard(BaseModel):
     answer: str
 
 
+class FlashcardDB(Flashcard):
+    """Flashcard persisted in the database."""
+
+    id: int = Field(..., example=1)
+
+
 class FlashcardsOut(BaseModel):
     """Response containing a list of flashcards."""
 
     flashcards: List[Flashcard]
+
+
+class FlashcardsDBOut(BaseModel):
+    """List of flashcards including DB ids."""
+
+    flashcards: List[FlashcardDB]
+
+
+class ReviewIn(BaseModel):
+    """Payload for reviewing a flashcard."""
+
+    flashcard_id: int = Field(..., example=1)
+    quality: int = Field(..., ge=0, le=5, example=5)
+
+
+class ReviewOut(BaseModel):
+    """Result of a review action."""
+
+    id: int
+    next_review: str
+    interval: int

--- a/packages/core/models.py
+++ b/packages/core/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import datetime as _dt
 from typing import List
-from sqlmodel import SQLModel, Field, Relationship
+from sqlmodel import SQLModel, Field
 
 
 class User(SQLModel, table=True):
@@ -19,7 +19,6 @@ class User(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     email: str = Field(index=True, unique=True, nullable=False)
     created_at: _dt.datetime = Field(default_factory=_dt.datetime.utcnow)
-    flashcards: List["Flashcard"] = Relationship(back_populates="owner")
 
 
 class Feed(SQLModel, table=True):
@@ -53,7 +52,6 @@ class Flashcard(SQLModel, table=True):
     repetitions: int = 0
     next_review: _dt.date = Field(default_factory=_dt.date.today)
 
-    owner: User = Relationship(back_populates="flashcards")
 
 
 __all__: list[str] = [

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,10 +1,16 @@
-from fastapi.testclient import TestClient
+import httpx
+import os
+import anyio
 
+os.environ["DATABASE_URL"] = "sqlite://"
 from apps.worker.main import app
 
 
 def test_health_check():
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    async def run() -> None:
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/health")
+            assert response.status_code == 200
+            assert response.json() == {"status": "ok"}
+
+    anyio.run(run)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,7 +1,10 @@
 import json
+import httpx
+from openai import APIError
+import os
+import anyio
 
-from fastapi.testclient import TestClient
-
+os.environ["DATABASE_URL"] = "sqlite://"
 from apps.worker.main import app, client as openai_client
 import types
 import pytest
@@ -24,23 +27,51 @@ def mock_openai(monkeypatch):
     yield
 
 
-test_client = TestClient(app, raise_server_exceptions=False)
+async def request(method: str, url: str, **kwargs):
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.request(method, url, **kwargs)
+        return resp
 
 
 def test_summarise_route():
-    resp = test_client.post("/summarise", json={"text": "OpenAI builds AI systems."})
-    assert resp.status_code == 200
-    # summarise returns dummy summary string
-    assert resp.json()["summary"] == '[{"question":"Q","answer":"A"}]'
+    async def run():
+        resp = await request("POST", "/summarise", json={"text": "OpenAI builds AI systems."})
+        assert resp.status_code == 200
+        assert resp.json()["summary"] == '[{"question":"Q","answer":"A"}]'
+
+    anyio.run(run)
+
+
+def test_summarise_validation_error():
+    async def run():
+        resp = await request("POST", "/summarise", json={})
+        assert resp.status_code == 422
+
+    anyio.run(run)
+
+
+def test_summarise_openai_error(monkeypatch):
+    async def fail_create(*args, **kwargs):
+        raise APIError("boom", request=None, body=None)
+
+    monkeypatch.setattr(openai_client.chat.completions, "create", fail_create)
+    async def run():
+        resp = await request("POST", "/summarise", json={"text": "hi"})
+        assert resp.status_code == 502
+        assert resp.json()["detail"] == "OpenAI error"
+
+    anyio.run(run)
 
 
 def test_flashcards_route_schema():
     """Ensure response model keys are correct when mocked."""
     payload = {"text": "Python is a popular programming language."}
-    resp = test_client.post("/flashcards", json=payload)
-    assert resp.status_code == 200
-    data = resp.json()
-    assert "flashcards" in data
-    # mock returns list with dummy-response; structure check only
-    for card in data["flashcards"]:
-        assert set(card) == {"question", "answer"}
+    async def run():
+        resp = await request("POST", "/flashcards", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "flashcards" in data
+        for card in data["flashcards"]:
+            assert set(card) == {"id", "question", "answer"}
+
+    anyio.run(run)


### PR DESCRIPTION
## Summary
- build DB-backed endpoints in worker app
- add health check at `/health`
- generate flashcards and persist them
- fetch today's deck and review cards
- add error handling and docs examples
- rewrite tests using HTTPX client

## Testing
- `pytest -q`