### PR TITLE
Add Alembic migrations and async DB helpers

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = env:DATABASE_URL
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,65 @@
+"""Alembic environment setup."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
+from sqlmodel import SQLModel
+
+from alembic import context
+
+from packages.core import models  # noqa: WPS433
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = SQLModel.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in offline mode."""
+
+    url = os.getenv("DATABASE_URL", config.get_main_option("sqlalchemy.url"))
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    """Run migrations in online mode."""
+
+    configuration = config.get_section(config.config_ini_section)
+    url = os.getenv("DATABASE_URL", configuration.get("sqlalchemy.url"))
+    configuration["sqlalchemy.url"] = url
+    connectable = async_engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())
+

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,63 @@
+"""Initial schema."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+    )
+    op.create_index("ix_user_email", "user", ["email"], unique=True)
+
+    op.create_table(
+        "feed",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("handle", sa.String(), nullable=False),
+        sa.Column("last_post_id", sa.String(), nullable=True),
+    )
+    op.create_index("ix_feed_handle", "feed", ["handle"], unique=True)
+
+    op.create_table(
+        "post",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("feed_id", sa.Integer(), sa.ForeignKey("feed.id"), nullable=False),
+        sa.Column("tweet_id", sa.String(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+    )
+    op.create_index("ix_post_tweet_id", "post", ["tweet_id"], unique=True)
+
+    op.create_table(
+        "flashcard",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("owner_id", sa.Integer(), sa.ForeignKey("user.id"), nullable=False),
+        sa.Column("post_id", sa.Integer(), sa.ForeignKey("post.id"), nullable=False),
+        sa.Column("question", sa.Text(), nullable=False),
+        sa.Column("answer", sa.Text(), nullable=False),
+        sa.Column("ease_factor", sa.Float(), nullable=False, server_default="2.5"),
+        sa.Column("interval", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("repetitions", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("next_review", sa.Date(), nullable=False, server_default=sa.text("CURRENT_DATE")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("flashcard")
+    op.drop_index("ix_post_tweet_id", table_name="post")
+    op.drop_table("post")
+    op.drop_index("ix_feed_handle", table_name="feed")
+    op.drop_table("feed")
+    op.drop_index("ix_user_email", table_name="user")
+    op.drop_table("user")
+

--- a/infra/github/ci.yml
+++ b/infra/github/ci.yml
@@ -27,9 +27,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run migrations
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:password@localhost:5432/postgres
+        run: alembic upgrade head
       - name: Run pytest
         env:
           OPENAI_API_KEY: "dummy-key"
+          DATABASE_URL: postgresql+asyncpg://postgres:password@localhost:5432/postgres
         run: pytest -q
 
   frontend:

--- a/packages/db/__init__.py
+++ b/packages/db/__init__.py
@@ -1,0 +1,6 @@
+"""DB helper exports."""
+
+from .session import engine, async_session_maker, init_db, get_session
+
+__all__ = ["engine", "async_session_maker", "init_db", "get_session"]
+

--- a/packages/db/session.py
+++ b/packages/db/session.py
@@ -1,0 +1,39 @@
+"""Async SQLModel session helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from sqlmodel import SQLModel
+
+
+DATABASE_URL: str = os.getenv(
+    "DATABASE_URL",
+    "postgresql+asyncpg://postgres:postgres@localhost:5432/vibe",
+)
+
+engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+
+async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def init_db() -> None:
+    """Create all tables using SQLModel metadata."""
+
+    from packages.core import models as _m  # noqa: WPS433
+
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Yield an ``AsyncSession`` instance."""
+
+    async with async_session_maker() as session:
+        yield session
+
+
+__all__ = ["engine", "async_session_maker", "init_db", "get_session"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ python-dotenv==1.0.1
 psycopg2-binary==2.9.9
 loguru==0.7.2
 anyio==4.3.0
+alembic==1.13.1

--- a/scripts/create_db.py
+++ b/scripts/create_db.py
@@ -1,0 +1,17 @@
+"""Initialize the database via Alembic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from alembic.config import Config
+from alembic import command
+
+
+def main() -> None:
+    cfg = Config(str(Path(__file__).resolve().parents[1] / "alembic.ini"))
+    command.upgrade(cfg, "head")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+
+@pytest.fixture(scope="session", autouse=True)
+def apply_migrations() -> None:
+    """Apply Alembic migrations before tests run."""
+
+    cfg = Config(str(ROOT / "alembic.ini"))
+    command.upgrade(cfg, "head")
+    yield

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,35 @@
+import pytest
+from sqlmodel import select
+
+from packages.core.models import User, Feed, Post, Flashcard
+from packages.db import async_session_maker, init_db
+
+
+@pytest.mark.asyncio
+async def test_model_crud_round_trip() -> None:
+    await init_db()
+    async with async_session_maker() as session:
+        user = User(email="me@example.com")
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+        feed = Feed(handle="test")
+        session.add(feed)
+        await session.commit()
+        await session.refresh(feed)
+
+        post = Post(feed_id=feed.id, tweet_id="t1", text="hello")
+        session.add(post)
+        await session.commit()
+        await session.refresh(post)
+
+        card = Flashcard(owner_id=user.id, post_id=post.id, question="Q", answer="A")
+        session.add(card)
+        await session.commit()
+
+        result = await session.exec(select(Flashcard).where(Flashcard.id == card.id))
+        fetched = result.one()
+        assert fetched.question == "Q"
+        assert fetched.owner_id == user.id
+


### PR DESCRIPTION
## Summary
- add alembic configuration and initial migration
- create async SQLModel session helpers
- provide script for running migrations
- run migrations in CI before tests
- test database CRUD round trip

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'command' from 'alembic')*