### PR TITLE
Fix SM-2 review logic and add regression test

### DIFF
--- a/apps/worker/main.py
+++ b/apps/worker/main.py
@@ -135,17 +135,16 @@ async def review(payload: ReviewIn) -> ReviewOut:
         if not card:
             raise HTTPException(status_code=404, detail="Flashcard not found")
 
-        next_review, ease, interval, reps = sm2(
-            dt.date.today(),
-            payload.quality,
-            card.ease_factor,
-            card.interval,
+        reps, interval, ease = sm2(
             card.repetitions,
+            card.interval,
+            card.ease_factor,
+            payload.quality,
         )
-        card.next_review = next_review
-        card.ease_factor = ease
-        card.interval = interval
         card.repetitions = reps
+        card.interval = interval
+        card.ease_factor = ease
+        card.next_review = dt.date.today() + dt.timedelta(days=interval)
         ses.add(card)
         ses.commit()
         ses.refresh(card)

--- a/packages/db/session.py
+++ b/packages/db/session.py
@@ -6,7 +6,9 @@ import os
 from typing import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
-from sqlmodel import SQLModel
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine
+from sqlmodel import SQLModel, Session
 
 
 DATABASE_URL: str = os.getenv(
@@ -14,25 +16,62 @@ DATABASE_URL: str = os.getenv(
     "postgresql+asyncpg://postgres:postgres@localhost:5432/vibe",
 )
 
-engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+if DATABASE_URL.startswith("sqlite"):  # fallback to sync driver for tests
+    # create synchronous engine and wrap in async interface
+    _sync_engine = create_engine(DATABASE_URL, echo=False, future=True)
+    _sync_sessionmaker = sessionmaker(_sync_engine, expire_on_commit=False, class_=Session)
 
-async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    class FakeAsyncSession:
+        """Minimal async wrapper around a sync Session."""
 
+        def __init__(self) -> None:
+            self._session = _sync_sessionmaker()
 
-async def init_db() -> None:
-    """Create all tables using SQLModel metadata."""
+        async def __aenter__(self) -> "FakeAsyncSession":
+            return self
 
-    from packages.core import models as _m  # noqa: WPS433
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            self._session.close()
 
-    async with engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
+        def add(self, *args, **kwargs) -> None:  # pragma: no cover - passthrough
+            self._session.add(*args, **kwargs)
 
+        async def commit(self) -> None:
+            self._session.commit()
 
-async def get_session() -> AsyncGenerator[AsyncSession, None]:
-    """Yield an ``AsyncSession`` instance."""
+        async def refresh(self, obj) -> None:
+            self._session.refresh(obj)
 
-    async with async_session_maker() as session:
-        yield session
+        async def exec(self, statement):
+            return self._session.exec(statement)
+
+    def async_session_maker() -> FakeAsyncSession:  # noqa: D401 - factory
+        """Return a new ``FakeAsyncSession``."""
+
+        return FakeAsyncSession()
+
+    async def init_db() -> None:
+        SQLModel.metadata.create_all(_sync_engine)
+
+    async def get_session() -> AsyncGenerator[FakeAsyncSession, None]:
+        async with FakeAsyncSession() as session:
+            yield session
+
+    engine = _sync_engine
+else:
+    engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+
+    async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def init_db() -> None:
+        from packages.core import models as _m  # noqa: WPS433
+
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    async def get_session() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_maker() as session:
+            yield session
 
 
 __all__ = ["engine", "async_session_maker", "init_db", "get_session"]


### PR DESCRIPTION
## Summary
- update the review route to call `sm2` using card fields and compute `next_review`
- add sqlite fallback for async DB utilities used in tests
- allow Alembic migrations to run with a sync sqlite engine
- add regression test for the review endpoint

## Testing
- `pytest -q`