### PR TITLE
Refactor worker cron into separate modules

### DIFF
--- a/apps/worker/ingest_loop.py
+++ b/apps/worker/ingest_loop.py
@@ -1,0 +1,36 @@
+"""AnyIO loop for daily feed ingestion."""
+from __future__ import annotations
+
+import anyio
+from loguru import logger
+
+from apps.worker.ingestors.twitter import ingest_handles
+from apps.worker import init_db
+
+HANDLES = [
+    "dr_cintas",
+    "GoogleLabs",
+    "kregenrek",
+    "GeminiApp",
+    "OpenAI",
+    "AnthropicAI",
+    "GoogleAI",
+]
+
+
+async def job() -> None:
+    """Run a single ingestion job."""
+    logger.info("Running ingest job…")
+    ingest_handles(HANDLES)
+
+
+async def main() -> None:
+    """Run ingestion job once per day."""
+    init_db()
+    while True:
+        await job()
+        await anyio.sleep(60 * 60 * 24)
+
+
+if __name__ == "__main__":
+    anyio.run(main)

--- a/apps/worker/scheduler.py
+++ b/apps/worker/scheduler.py
@@ -31,7 +31,7 @@ def main(argv: list[str] | None = None) -> None:
     """Simple CLI entrypoint."""
     import argparse
 
-    parser = argparse.ArgumentParser(description="Worker cron utilities")
+    parser = argparse.ArgumentParser(description="Worker scheduler utilities")
     parser.add_argument("command", choices=["daily", "run"], help="Run once or start scheduler")
     args = parser.parse_args(argv)
 
@@ -43,40 +43,3 @@ def main(argv: list[str] | None = None) -> None:
 
 if __name__ == "__main__":
     main()
-
-"""Simple AnyIO cron to run ingestor daily."""
-from __future__ import annotations
-
-import anyio
-from loguru import logger
-
-from packages.core.models import Feed
-from apps.worker.ingestors.twitter import ingest_handles
-from apps.worker import init_db
-
-HANDLES = [
-    "dr_cintas",
-    "GoogleLabs",
-    "kregenrek",
-    "GeminiApp",
-    "OpenAI",
-    "AnthropicAI",
-    "GoogleAI",
-]
-
-
-async def job() -> None:  # noqa: D401
-    logger.info("Running ingest job…")
-    ingest_handles(HANDLES)
-
-
-async def main() -> None:  # noqa: D401
-    init_db()
-    while True:
-        await job()
-        # sleep 24h
-        await anyio.sleep(60 * 60 * 24)
-
-
-if __name__ == "__main__":
-    anyio.run(main)


### PR DESCRIPTION
## Summary
- remove `cron.py` and split logic into dedicated modules
- add `scheduler.py` for spaced-repetition APScheduler
- add `ingest_loop.py` for ingestion daemon

## Testing
- `pytest -q` *(fails: The asyncio extension requires an async driver to be used)*