### PR TITLE
Allow configurable worker URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ npm install
 npm run dev
 ```
 
+## Environment variables
+
+| Variable     | Purpose                               | Default                   |
+| ------------ | ------------------------------------- | ------------------------- |
+| `WORKER_URL` | Base URL of the worker API consumed by the Next.js routes | `http://localhost:8000` |
+
 ## Engineering Principles (Elon Musk’s 5 steps)
 
 1. **Question every requirement** – keep only what drives engagement.  

--- a/apps/web/pages/api/flashcards.ts
+++ b/apps/web/pages/api/flashcards.ts
@@ -1,11 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import axios from 'axios';
 
+const WORKER_URL = process.env.WORKER_URL || 'http://localhost:8000';
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
 
   try {
-    const { data } = await axios.post('http://localhost:8000/flashcards', req.body);
+    const { data } = await axios.post(`${WORKER_URL}/flashcards`, req.body);
     res.status(200).json(data);
   } catch (error: any) {
     res.status(500).json({ error: error.message });

--- a/apps/web/pages/api/summarise.ts
+++ b/apps/web/pages/api/summarise.ts
@@ -1,11 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import axios from 'axios';
 
+const WORKER_URL = process.env.WORKER_URL || 'http://localhost:8000';
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
 
   try {
-    const { data } = await axios.post('http://localhost:8000/summarise', req.body);
+    const { data } = await axios.post(`${WORKER_URL}/summarise`, req.body);
     res.status(200).json(data);
   } catch (error: any) {
     res.status(500).json({ error: error.message });


### PR DESCRIPTION
## Summary
- make worker URL configurable for `summarise` and `flashcards` API routes
- document `WORKER_URL` environment variable in README

## Testing
- `pytest -q` *(fails: InvalidRequestError for async driver)*