### PR TITLE
Add Task Master board for PRD

### DIFF
--- a/docs/task-master-prd.md
+++ b/docs/task-master-prd.md
@@ -1,0 +1,24 @@
+# Task Master Board – PRD
+
+This board tracks the steps required to produce the initial Product Requirements Document for **Vibe Coder Flashcards**.
+
+## Task Board
+
+| Task | Owner | Status | Due |
+| ---- | ----- | ------ | ---- |
+| Draft core product overview | Product Lead | In Progress | 2025‑06‑12 |
+| Define target audience | Product Lead | TODO | 2025‑06‑12 |
+| Outline core features | Engineering Lead | TODO | 2025‑06‑13 |
+| Write user stories | PM | TODO | 2025‑06‑14 |
+| List functional requirements | Engineering Lead | TODO | 2025‑06‑14 |
+| List non-functional requirements | Engineering Lead | TODO | 2025‑06‑14 |
+| Establish KPIs | Data Analyst | TODO | 2025‑06‑15 |
+| Review and finalize PRD | Stakeholders | TODO | 2025‑06‑16 |
+| Publish PRD in docs/PRD.md | Product Lead | TODO | 2025‑06‑16 |
+| Iterate based on feedback | All | TODO | 2025‑06‑18 |
+
+### Usage
+
+1. Update the **Status** column as tasks move forward (`TODO`, `In Progress`, `Done`).
+2. Adjust due dates as necessary.
+3. Keep the PRD up to date by linking to completed sections in `docs/PRD.md`.


### PR DESCRIPTION
## Summary
- expand `docs/task-master-prd.md` with due dates and usage notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68479cb0c42c8322ae8707f9f2a6e00a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a task board outlining key steps and responsibilities for creating the "Vibe Coder Flashcards" Product Requirements Document (PRD). The board includes task descriptions, owners, statuses, due dates, and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->